### PR TITLE
feat: Chunk dataclass — shared data contract between pipeline stages

### DIFF
--- a/aidente_voice/models.py
+++ b/aidente_voice/models.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass
+class Chunk:
+    index: int
+    type: Literal["tts", "pause", "sfx", "gacha"]
+    text: str | None = None
+    duration: float | None = None
+    speed: float = 1.0
+    gacha_n: int = 1
+    sfx_name: str | None = None
+    sfx_fade: float = 0.05

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,23 @@
+from aidente_voice.models import Chunk
+
+def test_tts_chunk_defaults():
+    c = Chunk(index=0, type="tts", text="hello")
+    assert c.speed == 1.0
+    assert c.gacha_n == 1
+    assert c.sfx_name is None
+    assert c.sfx_fade == 0.05
+
+def test_pause_chunk():
+    c = Chunk(index=1, type="pause", duration=0.5)
+    assert c.duration == 0.5
+    assert c.text is None
+
+def test_sfx_chunk_custom_fade():
+    c = Chunk(index=2, type="sfx", sfx_name="laugh", sfx_fade=0.1)
+    assert c.sfx_name == "laugh"
+    assert c.sfx_fade == 0.1
+
+def test_gacha_chunk():
+    c = Chunk(index=3, type="gacha", text="test", gacha_n=3)
+    assert c.gacha_n == 3
+    assert c.type == "gacha"


### PR DESCRIPTION
## Summary
- Adds `aidente_voice/models.py` with `Chunk` dataclass — the shared data contract used across all pipeline stages
- Fields: `index`, `type` (tts/pause/sfx/gacha), `text`, `duration`, `speed`, `gacha_n`, `sfx_name`, `sfx_fade`
- 4 tests covering all chunk types and default values

Closes #3

## Test plan
- [ ] `uv run pytest tests/test_models.py -v` → 4 PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)