### PR TITLE
feat: tag parser — tokenize script text with pause/speed/sfx/gacha tags

### DIFF
--- a/aidente_voice/parser.py
+++ b/aidente_voice/parser.py
@@ -1,0 +1,82 @@
+import re
+from aidente_voice.models import Chunk
+
+TAG_RE = re.compile(r'<(speed|pause|gacha|sfx)=([^>]+)>')
+SENTENCE_END_RE = re.compile(r'(?<=[。！？])\s*|\n+')
+
+
+class ParseError(ValueError):
+    pass
+
+
+def _parse_sfx_args(value: str) -> tuple[str, float]:
+    """Parse sfx tag value like 'laugh' or 'laugh,fade=0.1'."""
+    parts = value.split(",")
+    name = parts[0].strip()
+    fade = 0.05
+    for part in parts[1:]:
+        if part.strip().startswith("fade="):
+            fade = float(part.strip()[5:])
+    return name, fade
+
+
+def parse(text: str) -> list[Chunk]:
+    """Parse script text with control tags into a Chunk list."""
+    tokens = []
+    last = 0
+    for m in TAG_RE.finditer(text):
+        if m.start() > last:
+            tokens.append(("text", text[last:m.start()]))
+        tokens.append(("tag", m.group(1), m.group(2)))
+        last = m.end()
+    if last < len(text):
+        tokens.append(("text", text[last:]))
+
+    chunks: list[Chunk] = []
+    index = 0
+    gacha_pending: int | None = None
+    deferred_sfx: list[tuple[str, float]] = []
+
+    def add(chunk: Chunk) -> None:
+        nonlocal index
+        chunk.index = index
+        chunks.append(chunk)
+        index += 1
+
+    for token in tokens:
+        if token[0] == "text":
+            segments = [s.strip() for s in SENTENCE_END_RE.split(token[1])]
+            segments = [s for s in segments if s]
+            for seg in segments:
+                if gacha_pending is not None:
+                    add(Chunk(index=0, type="gacha", text=seg, gacha_n=gacha_pending))
+                    gacha_pending = None
+                    for sfx_name, sfx_fade in deferred_sfx:
+                        add(Chunk(index=0, type="sfx", sfx_name=sfx_name, sfx_fade=sfx_fade))
+                    deferred_sfx.clear()
+                else:
+                    add(Chunk(index=0, type="tts", text=seg))
+
+        elif token[0] == "tag":
+            _, name, value = token
+            if name == "speed":
+                if not chunks or chunks[-1].type not in ("tts", "gacha"):
+                    raise ParseError(
+                        f"<speed> tag has no preceding sentence to attach to."
+                    )
+                chunks[-1].speed = float(value)
+
+            elif name == "pause":
+                add(Chunk(index=0, type="pause", duration=float(value)))
+
+            elif name == "gacha":
+                gacha_pending = int(value)
+
+            elif name == "sfx":
+                sfx_name, sfx_fade = _parse_sfx_args(value)
+                if gacha_pending is not None:
+                    deferred_sfx.append((sfx_name, sfx_fade))
+                else:
+                    add(Chunk(index=0, type="sfx", sfx_name=sfx_name, sfx_fade=sfx_fade))
+
+    return chunks

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,72 @@
+import pytest
+from aidente_voice.parser import parse, ParseError
+
+def test_plain_tts():
+    chunks = parse("Hello world。")
+    assert len(chunks) == 1
+    assert chunks[0].type == "tts"
+    assert chunks[0].text == "Hello world。"
+    assert chunks[0].speed == 1.0
+
+def test_speed_tag_attaches_to_preceding():
+    chunks = parse("Slow sentence。 <speed=0.85>")
+    assert chunks[0].type == "tts"
+    assert chunks[0].speed == 0.85
+
+def test_speed_tag_at_start_raises():
+    with pytest.raises(ParseError, match="no preceding sentence"):
+        parse("<speed=0.85> Some sentence。")
+
+def test_pause_tag():
+    chunks = parse("First。 <pause=1.5> Second。")
+    assert chunks[0].type == "tts"
+    assert chunks[0].text == "First。"
+    assert chunks[1].type == "pause"
+    assert chunks[1].duration == 1.5
+    assert chunks[2].type == "tts"
+    assert chunks[2].text == "Second。"
+
+def test_sfx_tag_simple():
+    chunks = parse("Hello。 <sfx=laugh>")
+    assert chunks[0].type == "tts"
+    assert chunks[1].type == "sfx"
+    assert chunks[1].sfx_name == "laugh"
+    assert chunks[1].sfx_fade == 0.05
+
+def test_sfx_tag_custom_fade():
+    chunks = parse("Hello。 <sfx=laugh,fade=0.1>")
+    assert chunks[1].sfx_fade == 0.1
+
+def test_sfx_fade_zero():
+    chunks = parse("Hello。 <sfx=laugh,fade=0>")
+    assert chunks[1].sfx_fade == 0.0
+
+def test_gacha_consumes_next_text():
+    chunks = parse("<gacha=3> Uncertain sentence。")
+    assert len(chunks) == 1
+    assert chunks[0].type == "gacha"
+    assert chunks[0].text == "Uncertain sentence。"
+    assert chunks[0].gacha_n == 3
+
+def test_gacha_defers_sfx_after_text():
+    chunks = parse("<gacha=3> <sfx=laugh> Uncertain sentence。")
+    assert chunks[0].type == "gacha"
+    assert chunks[0].text == "Uncertain sentence。"
+    assert chunks[1].type == "sfx"
+    assert chunks[1].sfx_name == "laugh"
+
+def test_full_example():
+    text = "接下來我們要講述一個非常關鍵的底層概念。 <speed=0.85>\n很多人在這裡會搞錯， <pause=0.5> <gacha=3> <sfx=laugh> 其實這沒有想像中困難。"
+    chunks = parse(text)
+    assert len(chunks) == 5
+    assert chunks[0].type == "tts" and chunks[0].speed == 0.85
+    assert chunks[1].type == "tts"
+    assert chunks[2].type == "pause" and chunks[2].duration == 0.5
+    assert chunks[3].type == "gacha" and chunks[3].gacha_n == 3
+    assert chunks[4].type == "sfx" and chunks[4].sfx_name == "laugh"
+    for i, c in enumerate(chunks):
+        assert c.index == i
+
+def test_empty_text_segments_ignored():
+    chunks = parse("Hello。\n\nWorld。")
+    assert len(chunks) == 2


### PR DESCRIPTION
## Summary
- Adds `aidente_voice/parser.py` with `parse(text) -> list[Chunk]`
- Supports `<pause=X>`, `<speed=X>`, `<sfx=name[,fade=X]>`, `<gacha=N>` tags
- `<speed>` attaches to preceding sentence; raises `ParseError` if none
- `<gacha=N>` defers any `<sfx>` tags between it and the next text, inserting them after the gacha chunk
- 11 tests covering all tag types, edge cases, and sequential index assignment

Closes #4

## Test plan
- [ ] `uv run pytest tests/test_parser.py -v` → 11 PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)