### PR TITLE
feat: TTSClient Protocol + ModalTTSClient with exponential retry

### DIFF
--- a/aidente_voice/tts/client.py
+++ b/aidente_voice/tts/client.py
@@ -1,0 +1,5 @@
+from typing import Protocol
+
+
+class TTSClient(Protocol):
+    async def synthesize(self, text: str, seed: int = 0) -> bytes: ...

--- a/aidente_voice/tts/modal_client.py
+++ b/aidente_voice/tts/modal_client.py
@@ -1,0 +1,31 @@
+import asyncio
+import requests
+from aidente_voice.tts.client import TTSClient  # noqa: F401 (for type checking)
+
+_RETRY_DELAYS = [1.0, 2.0, 4.0]
+
+
+class ModalTTSClient:
+    def __init__(self, endpoint_url: str) -> None:
+        self._url = endpoint_url
+
+    async def synthesize(self, text: str, seed: int = 0) -> bytes:
+        payload = {"text": text, "seed": seed}
+        last_exc: Exception | None = None
+
+        for attempt, delay in enumerate([0.0] + _RETRY_DELAYS):
+            if delay:
+                await asyncio.sleep(delay)
+            try:
+                response = requests.post(self._url, json=payload, timeout=60)
+                if response.status_code == 200:
+                    return response.content
+                last_exc = RuntimeError(
+                    f"TTS API failed: status {response.status_code}"
+                )
+            except requests.RequestException as e:
+                last_exc = e
+
+        raise RuntimeError(
+            f"TTS API failed after {len(_RETRY_DELAYS) + 1} attempts: {last_exc}"
+        )

--- a/tests/tts/test_modal_client.py
+++ b/tests/tts/test_modal_client.py
@@ -1,0 +1,65 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from aidente_voice.tts.modal_client import ModalTTSClient
+
+
+@pytest.fixture
+def client():
+    return ModalTTSClient(endpoint_url="https://fake.modal.run/tts")
+
+
+@pytest.mark.asyncio
+async def test_synthesize_returns_bytes(client):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b"RIFF....fake_wav_bytes"
+
+    with patch("requests.post", return_value=mock_response):
+        result = await client.synthesize("Hello world", seed=42)
+
+    assert isinstance(result, bytes)
+    assert result == b"RIFF....fake_wav_bytes"
+
+
+@pytest.mark.asyncio
+async def test_synthesize_sends_correct_payload(client):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b"audio"
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        await client.synthesize("Test sentence", seed=1337)
+
+    call_kwargs = mock_post.call_args
+    payload = call_kwargs.kwargs.get("json") or call_kwargs.args[1]
+    assert payload["text"] == "Test sentence"
+    assert payload["seed"] == 1337
+
+
+@pytest.mark.asyncio
+async def test_synthesize_retries_on_failure(client):
+    fail_response = MagicMock()
+    fail_response.status_code = 500
+    fail_response.content = b""
+
+    ok_response = MagicMock()
+    ok_response.status_code = 200
+    ok_response.content = b"audio"
+
+    with patch("requests.post", side_effect=[fail_response, fail_response, ok_response]):
+        with patch("asyncio.sleep"):  # skip actual delays
+            result = await client.synthesize("Test", seed=0)
+
+    assert result == b"audio"
+
+
+@pytest.mark.asyncio
+async def test_synthesize_raises_after_max_retries(client):
+    fail_response = MagicMock()
+    fail_response.status_code = 500
+    fail_response.content = b""
+
+    with patch("requests.post", return_value=fail_response):
+        with patch("asyncio.sleep"):
+            with pytest.raises(RuntimeError, match="TTS API failed"):
+                await client.synthesize("Test", seed=0)


### PR DESCRIPTION
## Summary
- Adds `aidente_voice/tts/client.py` — `TTSClient` Protocol (adapter interface for any TTS backend)
- Adds `aidente_voice/tts/modal_client.py` — `ModalTTSClient` posts JSON to Modal HTTP endpoint, retries on non-200 with delays [1s, 2s, 4s], raises `RuntimeError` after 4 attempts
- 4 tests covering return type, payload correctness, retry on failure, max-retry error

Closes #5

## Test plan
- [ ] `uv run pytest tests/tts/test_modal_client.py -v` → 4 PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)