### PR TITLE
feat: audio_player — macOS afplay wrapper for blocking playback

### DIFF
--- a/aidente_voice/audio_player.py
+++ b/aidente_voice/audio_player.py
@@ -1,0 +1,7 @@
+import subprocess
+from pathlib import Path
+
+
+def play(path: str | Path) -> None:
+    """Play audio file via afplay. Blocks until playback completes."""
+    subprocess.run(["afplay", str(path)], check=True)

--- a/tests/test_audio_player.py
+++ b/tests/test_audio_player.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+from pathlib import Path
+from aidente_voice.audio_player import play
+
+
+def test_play_calls_afplay(tmp_path):
+    fake_wav = tmp_path / "test.wav"
+    fake_wav.write_bytes(b"")
+
+    with patch("subprocess.run") as mock_run:
+        play(fake_wav)
+
+    mock_run.assert_called_once_with(["afplay", str(fake_wav)], check=True)
+
+
+def test_play_accepts_string_path(tmp_path):
+    fake_wav = tmp_path / "test.wav"
+    fake_wav.write_bytes(b"")
+
+    with patch("subprocess.run") as mock_run:
+        play(str(fake_wav))
+
+    mock_run.assert_called_once_with(["afplay", str(fake_wav)], check=True)


### PR DESCRIPTION
## Summary
- Adds `aidente_voice/audio_player.py` with `play(path)` — thin wrapper around `afplay` for blocking audio playback
- Accepts both `str` and `Path` inputs
- 2 tests verifying afplay is called with the correct arguments

Closes #6

## Test plan
- [ ] `uv run pytest tests/test_audio_player.py -v` → 2 PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)