### PR TITLE
feat: atempo post-processing — lossless time-stretch with auto-chain factorization

### DIFF
--- a/aidente_voice/audio_player.py
+++ b/aidente_voice/audio_player.py
@@ -1,0 +1,7 @@
+import subprocess
+from pathlib import Path
+
+
+def play(path: str | Path) -> None:
+    """Play audio file via afplay. Blocks until playback completes."""
+    subprocess.run(["afplay", str(path)], check=True)

--- a/aidente_voice/models.py
+++ b/aidente_voice/models.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass
+class Chunk:
+    index: int
+    type: Literal["tts", "pause", "sfx", "gacha"]
+    text: str | None = None
+    duration: float | None = None
+    speed: float = 1.0
+    gacha_n: int = 1
+    sfx_name: str | None = None
+    sfx_fade: float = 0.05

--- a/aidente_voice/parser.py
+++ b/aidente_voice/parser.py
@@ -1,0 +1,82 @@
+import re
+from aidente_voice.models import Chunk
+
+TAG_RE = re.compile(r'<(speed|pause|gacha|sfx)=([^>]+)>')
+SENTENCE_END_RE = re.compile(r'(?<=[。！？])\s*|\n+')
+
+
+class ParseError(ValueError):
+    pass
+
+
+def _parse_sfx_args(value: str) -> tuple[str, float]:
+    """Parse sfx tag value like 'laugh' or 'laugh,fade=0.1'."""
+    parts = value.split(",")
+    name = parts[0].strip()
+    fade = 0.05
+    for part in parts[1:]:
+        if part.strip().startswith("fade="):
+            fade = float(part.strip()[5:])
+    return name, fade
+
+
+def parse(text: str) -> list[Chunk]:
+    """Parse script text with control tags into a Chunk list."""
+    tokens = []
+    last = 0
+    for m in TAG_RE.finditer(text):
+        if m.start() > last:
+            tokens.append(("text", text[last:m.start()]))
+        tokens.append(("tag", m.group(1), m.group(2)))
+        last = m.end()
+    if last < len(text):
+        tokens.append(("text", text[last:]))
+
+    chunks: list[Chunk] = []
+    index = 0
+    gacha_pending: int | None = None
+    deferred_sfx: list[tuple[str, float]] = []
+
+    def add(chunk: Chunk) -> None:
+        nonlocal index
+        chunk.index = index
+        chunks.append(chunk)
+        index += 1
+
+    for token in tokens:
+        if token[0] == "text":
+            segments = [s.strip() for s in SENTENCE_END_RE.split(token[1])]
+            segments = [s for s in segments if s]
+            for seg in segments:
+                if gacha_pending is not None:
+                    add(Chunk(index=0, type="gacha", text=seg, gacha_n=gacha_pending))
+                    gacha_pending = None
+                    for sfx_name, sfx_fade in deferred_sfx:
+                        add(Chunk(index=0, type="sfx", sfx_name=sfx_name, sfx_fade=sfx_fade))
+                    deferred_sfx.clear()
+                else:
+                    add(Chunk(index=0, type="tts", text=seg))
+
+        elif token[0] == "tag":
+            _, name, value = token
+            if name == "speed":
+                if not chunks or chunks[-1].type not in ("tts", "gacha"):
+                    raise ParseError(
+                        f"<speed> tag has no preceding sentence to attach to."
+                    )
+                chunks[-1].speed = float(value)
+
+            elif name == "pause":
+                add(Chunk(index=0, type="pause", duration=float(value)))
+
+            elif name == "gacha":
+                gacha_pending = int(value)
+
+            elif name == "sfx":
+                sfx_name, sfx_fade = _parse_sfx_args(value)
+                if gacha_pending is not None:
+                    deferred_sfx.append((sfx_name, sfx_fade))
+                else:
+                    add(Chunk(index=0, type="sfx", sfx_name=sfx_name, sfx_fade=sfx_fade))
+
+    return chunks

--- a/aidente_voice/pipeline/postprocess.py
+++ b/aidente_voice/pipeline/postprocess.py
@@ -1,0 +1,46 @@
+import tempfile
+import os
+import ffmpeg
+
+AUDIO_SAMPLE_RATE = 24000
+
+
+def build_atempo_chain(speed: float) -> list[float]:
+    """Factorize speed into atempo filter values, each in [0.5, 2.0]."""
+    if speed == 1.0:
+        return [1.0]
+    factors: list[float] = []
+    remaining = speed
+    while remaining < 0.5:
+        factors.append(0.5)
+        remaining /= 0.5
+    while remaining > 2.0:
+        factors.append(2.0)
+        remaining /= 2.0
+    factors.append(remaining)
+    return factors
+
+
+def apply_speed(audio_bytes: bytes, speed: float) -> bytes:
+    """Apply time-stretch to audio bytes using ffmpeg atempo. Returns WAV bytes."""
+    if speed == 1.0:
+        return audio_bytes
+
+    factors = build_atempo_chain(speed)
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as in_f:
+        in_f.write(audio_bytes)
+        in_path = in_f.name
+
+    out_path = in_path.replace(".wav", "_out.wav")
+    try:
+        stream = ffmpeg.input(in_path).audio
+        for factor in factors:
+            stream = ffmpeg.filter(stream, "atempo", factor)
+        ffmpeg.output(stream, out_path).run(quiet=True, overwrite_output=True)
+        with open(out_path, "rb") as f:
+            return f.read()
+    finally:
+        os.unlink(in_path)
+        if os.path.exists(out_path):
+            os.unlink(out_path)

--- a/aidente_voice/tts/client.py
+++ b/aidente_voice/tts/client.py
@@ -1,0 +1,5 @@
+from typing import Protocol
+
+
+class TTSClient(Protocol):
+    async def synthesize(self, text: str, seed: int = 0) -> bytes: ...

--- a/aidente_voice/tts/modal_client.py
+++ b/aidente_voice/tts/modal_client.py
@@ -1,0 +1,31 @@
+import asyncio
+import requests
+from aidente_voice.tts.client import TTSClient  # noqa: F401 (for type checking)
+
+_RETRY_DELAYS = [1.0, 2.0, 4.0]
+
+
+class ModalTTSClient:
+    def __init__(self, endpoint_url: str) -> None:
+        self._url = endpoint_url
+
+    async def synthesize(self, text: str, seed: int = 0) -> bytes:
+        payload = {"text": text, "seed": seed}
+        last_exc: Exception | None = None
+
+        for attempt, delay in enumerate([0.0] + _RETRY_DELAYS):
+            if delay:
+                await asyncio.sleep(delay)
+            try:
+                response = requests.post(self._url, json=payload, timeout=60)
+                if response.status_code == 200:
+                    return response.content
+                last_exc = RuntimeError(
+                    f"TTS API failed: status {response.status_code}"
+                )
+            except requests.RequestException as e:
+                last_exc = e
+
+        raise RuntimeError(
+            f"TTS API failed after {len(_RETRY_DELAYS) + 1} attempts: {last_exc}"
+        )

--- a/tests/pipeline/test_postprocess.py
+++ b/tests/pipeline/test_postprocess.py
@@ -1,0 +1,62 @@
+import pytest
+from unittest.mock import patch, MagicMock, mock_open
+from aidente_voice.pipeline.postprocess import build_atempo_chain, apply_speed
+
+
+def test_chain_single_value_in_range():
+    assert build_atempo_chain(0.85) == pytest.approx([0.85])
+
+def test_chain_single_value_boundary():
+    assert build_atempo_chain(0.5) == pytest.approx([0.5])
+    assert build_atempo_chain(2.0) == pytest.approx([2.0])
+
+def test_chain_below_range():
+    chain = build_atempo_chain(0.3)
+    product = 1.0
+    for f in chain:
+        assert 0.5 <= f <= 2.0
+        product *= f
+    assert product == pytest.approx(0.3, rel=1e-4)
+
+def test_chain_above_range():
+    chain = build_atempo_chain(3.0)
+    product = 1.0
+    for f in chain:
+        assert 0.5 <= f <= 2.0
+        product *= f
+    assert product == pytest.approx(3.0, rel=1e-4)
+
+def test_chain_speed_one_is_noop():
+    assert build_atempo_chain(1.0) == pytest.approx([1.0])
+
+def test_apply_speed_calls_ffmpeg_filter(tmp_path):
+    """apply_speed calls ffmpeg.filter once per atempo factor."""
+    from unittest.mock import call
+    fake_bytes = b"RIFF" + b"\x00" * 100
+
+    mock_stream = MagicMock()
+
+    with patch("ffmpeg.input") as mock_input, \
+         patch("ffmpeg.filter", return_value=mock_stream) as mock_filter, \
+         patch("ffmpeg.output") as mock_output, \
+         patch("ffmpeg.run"), \
+         patch("builtins.open", mock_open(read_data=b"result_audio")), \
+         patch("os.unlink"), \
+         patch("tempfile.NamedTemporaryFile") as mock_tmp:
+
+        mock_tmp.return_value.__enter__ = lambda s: s
+        mock_tmp.return_value.__exit__ = MagicMock(return_value=False)
+        mock_tmp.return_value.name = "/tmp/fake.wav"
+        mock_input.return_value.audio = mock_stream
+
+        apply_speed(fake_bytes, speed=0.85)
+
+    # Should call ffmpeg.filter once for speed in [0.5, 2.0]
+    mock_filter.assert_called_once_with(mock_stream, "atempo", pytest.approx(0.85))
+
+
+def test_apply_speed_noop_on_speed_one():
+    """speed=1.0 returns input bytes unchanged without calling ffmpeg."""
+    fake_bytes = b"audio_data"
+    result = apply_speed(fake_bytes, speed=1.0)
+    assert result == fake_bytes

--- a/tests/test_audio_player.py
+++ b/tests/test_audio_player.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+from pathlib import Path
+from aidente_voice.audio_player import play
+
+
+def test_play_calls_afplay(tmp_path):
+    fake_wav = tmp_path / "test.wav"
+    fake_wav.write_bytes(b"")
+
+    with patch("subprocess.run") as mock_run:
+        play(fake_wav)
+
+    mock_run.assert_called_once_with(["afplay", str(fake_wav)], check=True)
+
+
+def test_play_accepts_string_path(tmp_path):
+    fake_wav = tmp_path / "test.wav"
+    fake_wav.write_bytes(b"")
+
+    with patch("subprocess.run") as mock_run:
+        play(str(fake_wav))
+
+    mock_run.assert_called_once_with(["afplay", str(fake_wav)], check=True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,23 @@
+from aidente_voice.models import Chunk
+
+def test_tts_chunk_defaults():
+    c = Chunk(index=0, type="tts", text="hello")
+    assert c.speed == 1.0
+    assert c.gacha_n == 1
+    assert c.sfx_name is None
+    assert c.sfx_fade == 0.05
+
+def test_pause_chunk():
+    c = Chunk(index=1, type="pause", duration=0.5)
+    assert c.duration == 0.5
+    assert c.text is None
+
+def test_sfx_chunk_custom_fade():
+    c = Chunk(index=2, type="sfx", sfx_name="laugh", sfx_fade=0.1)
+    assert c.sfx_name == "laugh"
+    assert c.sfx_fade == 0.1
+
+def test_gacha_chunk():
+    c = Chunk(index=3, type="gacha", text="test", gacha_n=3)
+    assert c.gacha_n == 3
+    assert c.type == "gacha"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,72 @@
+import pytest
+from aidente_voice.parser import parse, ParseError
+
+def test_plain_tts():
+    chunks = parse("Hello world。")
+    assert len(chunks) == 1
+    assert chunks[0].type == "tts"
+    assert chunks[0].text == "Hello world。"
+    assert chunks[0].speed == 1.0
+
+def test_speed_tag_attaches_to_preceding():
+    chunks = parse("Slow sentence。 <speed=0.85>")
+    assert chunks[0].type == "tts"
+    assert chunks[0].speed == 0.85
+
+def test_speed_tag_at_start_raises():
+    with pytest.raises(ParseError, match="no preceding sentence"):
+        parse("<speed=0.85> Some sentence。")
+
+def test_pause_tag():
+    chunks = parse("First。 <pause=1.5> Second。")
+    assert chunks[0].type == "tts"
+    assert chunks[0].text == "First。"
+    assert chunks[1].type == "pause"
+    assert chunks[1].duration == 1.5
+    assert chunks[2].type == "tts"
+    assert chunks[2].text == "Second。"
+
+def test_sfx_tag_simple():
+    chunks = parse("Hello。 <sfx=laugh>")
+    assert chunks[0].type == "tts"
+    assert chunks[1].type == "sfx"
+    assert chunks[1].sfx_name == "laugh"
+    assert chunks[1].sfx_fade == 0.05
+
+def test_sfx_tag_custom_fade():
+    chunks = parse("Hello。 <sfx=laugh,fade=0.1>")
+    assert chunks[1].sfx_fade == 0.1
+
+def test_sfx_fade_zero():
+    chunks = parse("Hello。 <sfx=laugh,fade=0>")
+    assert chunks[1].sfx_fade == 0.0
+
+def test_gacha_consumes_next_text():
+    chunks = parse("<gacha=3> Uncertain sentence。")
+    assert len(chunks) == 1
+    assert chunks[0].type == "gacha"
+    assert chunks[0].text == "Uncertain sentence。"
+    assert chunks[0].gacha_n == 3
+
+def test_gacha_defers_sfx_after_text():
+    chunks = parse("<gacha=3> <sfx=laugh> Uncertain sentence。")
+    assert chunks[0].type == "gacha"
+    assert chunks[0].text == "Uncertain sentence。"
+    assert chunks[1].type == "sfx"
+    assert chunks[1].sfx_name == "laugh"
+
+def test_full_example():
+    text = "接下來我們要講述一個非常關鍵的底層概念。 <speed=0.85>\n很多人在這裡會搞錯， <pause=0.5> <gacha=3> <sfx=laugh> 其實這沒有想像中困難。"
+    chunks = parse(text)
+    assert len(chunks) == 5
+    assert chunks[0].type == "tts" and chunks[0].speed == 0.85
+    assert chunks[1].type == "tts"
+    assert chunks[2].type == "pause" and chunks[2].duration == 0.5
+    assert chunks[3].type == "gacha" and chunks[3].gacha_n == 3
+    assert chunks[4].type == "sfx" and chunks[4].sfx_name == "laugh"
+    for i, c in enumerate(chunks):
+        assert c.index == i
+
+def test_empty_text_segments_ignored():
+    chunks = parse("Hello。\n\nWorld。")
+    assert len(chunks) == 2

--- a/tests/tts/test_modal_client.py
+++ b/tests/tts/test_modal_client.py
@@ -1,0 +1,65 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from aidente_voice.tts.modal_client import ModalTTSClient
+
+
+@pytest.fixture
+def client():
+    return ModalTTSClient(endpoint_url="https://fake.modal.run/tts")
+
+
+@pytest.mark.asyncio
+async def test_synthesize_returns_bytes(client):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b"RIFF....fake_wav_bytes"
+
+    with patch("requests.post", return_value=mock_response):
+        result = await client.synthesize("Hello world", seed=42)
+
+    assert isinstance(result, bytes)
+    assert result == b"RIFF....fake_wav_bytes"
+
+
+@pytest.mark.asyncio
+async def test_synthesize_sends_correct_payload(client):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b"audio"
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        await client.synthesize("Test sentence", seed=1337)
+
+    call_kwargs = mock_post.call_args
+    payload = call_kwargs.kwargs.get("json") or call_kwargs.args[1]
+    assert payload["text"] == "Test sentence"
+    assert payload["seed"] == 1337
+
+
+@pytest.mark.asyncio
+async def test_synthesize_retries_on_failure(client):
+    fail_response = MagicMock()
+    fail_response.status_code = 500
+    fail_response.content = b""
+
+    ok_response = MagicMock()
+    ok_response.status_code = 200
+    ok_response.content = b"audio"
+
+    with patch("requests.post", side_effect=[fail_response, fail_response, ok_response]):
+        with patch("asyncio.sleep"):  # skip actual delays
+            result = await client.synthesize("Test", seed=0)
+
+    assert result == b"audio"
+
+
+@pytest.mark.asyncio
+async def test_synthesize_raises_after_max_retries(client):
+    fail_response = MagicMock()
+    fail_response.status_code = 500
+    fail_response.content = b""
+
+    with patch("requests.post", return_value=fail_response):
+        with patch("asyncio.sleep"):
+            with pytest.raises(RuntimeError, match="TTS API failed"):
+                await client.synthesize("Test", seed=0)


### PR DESCRIPTION
## Summary
- Adds `aidente_voice/pipeline/postprocess.py` with `build_atempo_chain(speed)` and `apply_speed(audio_bytes, speed)`
- `build_atempo_chain` factorizes any speed value into factors within FFmpeg's valid `[0.5, 2.0]` range (e.g., `0.3 → [0.5, 0.6]`)
- `apply_speed` short-circuits on `speed=1.0` (no ffmpeg call); otherwise applies chained atempo filters
- 7 tests covering boundary values, below/above range chaining, noop, and ffmpeg mock verification

Closes #7

## Test plan
- [ ] `uv run pytest tests/pipeline/test_postprocess.py -v` → 7 PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)