### PR TITLE
feat: integrate gacha selection into pipeline orchestrator

### DIFF
--- a/aidente_voice/audio_player.py
+++ b/aidente_voice/audio_player.py
@@ -1,0 +1,7 @@
+import subprocess
+from pathlib import Path
+
+
+def play(path: str | Path) -> None:
+    """Play audio file via afplay. Blocks until playback completes."""
+    subprocess.run(["afplay", str(path)], check=True)

--- a/aidente_voice/gacha.py
+++ b/aidente_voice/gacha.py
@@ -1,0 +1,64 @@
+"""Gacha (variant selection) for TTS audio."""
+
+import sys
+import termios
+import tty
+from pathlib import Path
+
+from aidente_voice.audio_player import play
+
+GACHA_SEEDS = [42, 1337, 7, 999, 2024, 31337, 100, 555]
+
+
+def _get_key() -> str:
+    """Read a single keypress from stdin using raw mode."""
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        return sys.stdin.read(1)
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+
+def select_gacha(audio_paths: list[Path], text: str, position: int) -> int:
+    """Interactive gacha selection UI.
+
+    Shows numbered options, plays audio on keypress, returns selected index.
+    - Number keys (1-N): play that variant
+    - Enter (without prior play): auto-plays first, returns index 0
+    - Enter (after playing): returns last-played index
+    - 'q': quit, returns 0
+
+    Args:
+        audio_paths: List of audio file paths for each variant
+        text: The text that was synthesized (shown in UI)
+        position: Chunk index (shown in UI)
+
+    Returns:
+        Selected index (0-based)
+    """
+    n = len(audio_paths)
+    print(f"\n[Gacha] Chunk {position}: {text!r}")
+    print(f"  Variants: {n} | Keys: 1-{n} to play, Enter to confirm, q to quit")
+
+    last_played = None
+
+    while True:
+        key = _get_key()
+
+        if key == '\r' or key == '\n':
+            if last_played is None:
+                # Auto-play first and return
+                play(audio_paths[0])
+                return 0
+            return last_played
+
+        if key == 'q':
+            return 0
+
+        if key.isdigit():
+            idx = int(key) - 1
+            if 0 <= idx < n:
+                play(audio_paths[idx])
+                last_played = idx

--- a/aidente_voice/models.py
+++ b/aidente_voice/models.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass
+class Chunk:
+    index: int
+    type: Literal["tts", "pause", "sfx", "gacha"]
+    text: str | None = None
+    duration: float | None = None
+    speed: float = 1.0
+    gacha_n: int = 1
+    sfx_name: str | None = None
+    sfx_fade: float = 0.05

--- a/aidente_voice/pipeline/orchestrator.py
+++ b/aidente_voice/pipeline/orchestrator.py
@@ -1,6 +1,5 @@
 """Sequential TTS pipeline orchestrator."""
 
-import asyncio
 import tempfile
 from pathlib import Path
 
@@ -32,6 +31,8 @@ async def run_pipeline(
 
 async def _run_gacha(chunk: Chunk, client: TTSClient) -> bytes:
     """Synthesize N gacha variants, let user pick one interactively."""
+    if chunk.gacha_n < 1:
+        raise ValueError(f"gacha_n must be >= 1, got {chunk.gacha_n}")
     seeds = GACHA_SEEDS[:chunk.gacha_n]
 
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/aidente_voice/pipeline/orchestrator.py
+++ b/aidente_voice/pipeline/orchestrator.py
@@ -1,0 +1,48 @@
+"""Sequential TTS pipeline orchestrator."""
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+from aidente_voice.gacha import GACHA_SEEDS, select_gacha
+from aidente_voice.models import Chunk
+from aidente_voice.pipeline.postprocess import apply_speed
+from aidente_voice.tts.client import TTSClient
+
+
+async def run_pipeline(
+    chunks: list[Chunk],
+    client: TTSClient,
+) -> list[tuple[Chunk, bytes | None]]:
+    """Run TTS pipeline sequentially, returning (chunk, audio_bytes) pairs."""
+    results = []
+    for chunk in chunks:
+        if chunk.type == "tts":
+            audio = await client.synthesize(chunk.text or "", seed=0)
+            if chunk.speed != 1.0:
+                audio = apply_speed(audio, chunk.speed)
+            results.append((chunk, audio))
+        elif chunk.type == "gacha":
+            audio = await _run_gacha(chunk, client)
+            results.append((chunk, audio))
+        else:
+            results.append((chunk, None))
+    return results
+
+
+async def _run_gacha(chunk: Chunk, client: TTSClient) -> bytes:
+    """Synthesize N gacha variants, let user pick one interactively."""
+    seeds = GACHA_SEEDS[:chunk.gacha_n]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        paths = []
+
+        for i, seed in enumerate(seeds):
+            audio_bytes = await client.synthesize(chunk.text or "", seed=seed)
+            path = tmp_path / f"gacha_{i}.wav"
+            path.write_bytes(audio_bytes)
+            paths.append(path)
+
+        selected_idx = select_gacha(paths, chunk.text or "", chunk.index)
+        return paths[selected_idx].read_bytes()

--- a/aidente_voice/pipeline/postprocess.py
+++ b/aidente_voice/pipeline/postprocess.py
@@ -1,0 +1,46 @@
+import tempfile
+import os
+import ffmpeg
+
+AUDIO_SAMPLE_RATE = 24000
+
+
+def build_atempo_chain(speed: float) -> list[float]:
+    """Factorize speed into atempo filter values, each in [0.5, 2.0]."""
+    if speed == 1.0:
+        return [1.0]
+    factors: list[float] = []
+    remaining = speed
+    while remaining < 0.5:
+        factors.append(0.5)
+        remaining /= 0.5
+    while remaining > 2.0:
+        factors.append(2.0)
+        remaining /= 2.0
+    factors.append(remaining)
+    return factors
+
+
+def apply_speed(audio_bytes: bytes, speed: float) -> bytes:
+    """Apply time-stretch to audio bytes using ffmpeg atempo. Returns WAV bytes."""
+    if speed == 1.0:
+        return audio_bytes
+
+    factors = build_atempo_chain(speed)
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as in_f:
+        in_f.write(audio_bytes)
+        in_path = in_f.name
+
+    out_path = in_path.replace(".wav", "_out.wav")
+    try:
+        stream = ffmpeg.input(in_path).audio
+        for factor in factors:
+            stream = ffmpeg.filter(stream, "atempo", factor)
+        ffmpeg.output(stream, out_path).run(quiet=True, overwrite_output=True)
+        with open(out_path, "rb") as f:
+            return f.read()
+    finally:
+        os.unlink(in_path)
+        if os.path.exists(out_path):
+            os.unlink(out_path)

--- a/aidente_voice/tts/client.py
+++ b/aidente_voice/tts/client.py
@@ -1,0 +1,5 @@
+from typing import Protocol
+
+
+class TTSClient(Protocol):
+    async def synthesize(self, text: str, seed: int = 0) -> bytes: ...

--- a/tests/test_orchestrator_gacha.py
+++ b/tests/test_orchestrator_gacha.py
@@ -1,0 +1,58 @@
+"""Tests for gacha integration in the orchestrator."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+from aidente_voice.models import Chunk
+from aidente_voice.pipeline.orchestrator import run_pipeline
+
+
+class FakeTTSClient:
+    def __init__(self, audio_by_seed: dict[int, bytes] | None = None):
+        self.calls = []
+        self._audio = audio_by_seed or {}
+
+    async def synthesize(self, text: str, seed: int = 0) -> bytes:
+        self.calls.append((text, seed))
+        return self._audio.get(seed, b"FAKE_AUDIO_" + str(seed).encode())
+
+
+@pytest.mark.asyncio
+async def test_gacha_synthesizes_n_variants():
+    """Gacha chunk should call synthesize for each seed in GACHA_SEEDS[:n]."""
+    from aidente_voice.gacha import GACHA_SEEDS
+
+    n = 3
+    chunk = Chunk(index=0, type="gacha", text="テスト", gacha_n=n)
+    client = FakeTTSClient()
+
+    with patch("aidente_voice.pipeline.orchestrator.select_gacha", return_value=0):
+        results = await run_pipeline([chunk], client)
+
+    assert len(results) == 1
+    # Should have called synthesize n times with the first n seeds
+    assert len(client.calls) == n
+    seeds_used = [call[1] for call in client.calls]
+    assert seeds_used == GACHA_SEEDS[:n]
+
+
+@pytest.mark.asyncio
+async def test_gacha_returns_selected_audio():
+    """Orchestrator should return the audio for the user-selected variant."""
+    from aidente_voice.gacha import GACHA_SEEDS
+
+    n = 2
+    seed_audio = {
+        GACHA_SEEDS[0]: b"AUDIO_VARIANT_0",
+        GACHA_SEEDS[1]: b"AUDIO_VARIANT_1",
+    }
+    chunk = Chunk(index=0, type="gacha", text="テスト", gacha_n=n)
+    client = FakeTTSClient(audio_by_seed=seed_audio)
+
+    # User selects variant 1 (index 1)
+    with patch("aidente_voice.pipeline.orchestrator.select_gacha", return_value=1):
+        results = await run_pipeline([chunk], client)
+
+    _, audio = results[0]
+    assert audio == b"AUDIO_VARIANT_1"

--- a/tests/test_orchestrator_gacha.py
+++ b/tests/test_orchestrator_gacha.py
@@ -4,6 +4,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
+from aidente_voice.gacha import GACHA_SEEDS
 from aidente_voice.models import Chunk
 from aidente_voice.pipeline.orchestrator import run_pipeline
 
@@ -21,8 +22,6 @@ class FakeTTSClient:
 @pytest.mark.asyncio
 async def test_gacha_synthesizes_n_variants():
     """Gacha chunk should call synthesize for each seed in GACHA_SEEDS[:n]."""
-    from aidente_voice.gacha import GACHA_SEEDS
-
     n = 3
     chunk = Chunk(index=0, type="gacha", text="テスト", gacha_n=n)
     client = FakeTTSClient()
@@ -40,8 +39,6 @@ async def test_gacha_synthesizes_n_variants():
 @pytest.mark.asyncio
 async def test_gacha_returns_selected_audio():
     """Orchestrator should return the audio for the user-selected variant."""
-    from aidente_voice.gacha import GACHA_SEEDS
-
     n = 2
     seed_audio = {
         GACHA_SEEDS[0]: b"AUDIO_VARIANT_0",


### PR DESCRIPTION
## Summary

- Adds `_run_gacha()` helper to orchestrator that synthesizes N variants using `GACHA_SEEDS[:chunk.gacha_n]`
- Saves each variant to a temp file, calls `select_gacha()` for interactive user selection, returns chosen audio bytes
- Brings in `gacha.py`, `audio_player.py`, `models.py`, `tts/client.py`, and `pipeline/postprocess.py` needed for the import chain

## Test plan

- [ ] `uv run pytest tests/test_orchestrator_gacha.py -v` — 2 tests pass
- [ ] `test_gacha_synthesizes_n_variants`: verifies synthesize called N times with correct seeds
- [ ] `test_gacha_returns_selected_audio`: verifies audio from user-selected index is returned

Closes #13