### PR TITLE
test: Phase 2 integration tests for gacha workflow

### DIFF
--- a/aidente_voice/audio_player.py
+++ b/aidente_voice/audio_player.py
@@ -1,0 +1,7 @@
+import subprocess
+from pathlib import Path
+
+
+def play(path: str | Path) -> None:
+    """Play audio file via afplay. Blocks until playback completes."""
+    subprocess.run(["afplay", str(path)], check=True)

--- a/aidente_voice/gacha.py
+++ b/aidente_voice/gacha.py
@@ -1,0 +1,64 @@
+"""Gacha (variant selection) for TTS audio."""
+
+import sys
+import termios
+import tty
+from pathlib import Path
+
+from aidente_voice.audio_player import play
+
+GACHA_SEEDS = [42, 1337, 7, 999, 2024, 31337, 100, 555]
+
+
+def _get_key() -> str:
+    """Read a single keypress from stdin using raw mode."""
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        return sys.stdin.read(1)
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+
+def select_gacha(audio_paths: list[Path], text: str, position: int) -> int:
+    """Interactive gacha selection UI.
+
+    Shows numbered options, plays audio on keypress, returns selected index.
+    - Number keys (1-N): play that variant
+    - Enter (without prior play): auto-plays first, returns index 0
+    - Enter (after playing): returns last-played index
+    - 'q': quit, returns 0
+
+    Args:
+        audio_paths: List of audio file paths for each variant
+        text: The text that was synthesized (shown in UI)
+        position: Chunk index (shown in UI)
+
+    Returns:
+        Selected index (0-based)
+    """
+    n = len(audio_paths)
+    print(f"\n[Gacha] Chunk {position}: {text!r}")
+    print(f"  Variants: {n} | Keys: 1-{n} to play, Enter to confirm, q to quit")
+
+    last_played = None
+
+    while True:
+        key = _get_key()
+
+        if key == '\r' or key == '\n':
+            if last_played is None:
+                # Auto-play first and return
+                play(audio_paths[0])
+                return 0
+            return last_played
+
+        if key == 'q':
+            return 0
+
+        if key.isdigit():
+            idx = int(key) - 1
+            if 0 <= idx < n:
+                play(audio_paths[idx])
+                last_played = idx

--- a/aidente_voice/models.py
+++ b/aidente_voice/models.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass
+class Chunk:
+    index: int
+    type: Literal["tts", "pause", "sfx", "gacha"]
+    text: str | None = None
+    duration: float | None = None
+    speed: float = 1.0
+    gacha_n: int = 1
+    sfx_name: str | None = None
+    sfx_fade: float = 0.05

--- a/aidente_voice/parser.py
+++ b/aidente_voice/parser.py
@@ -1,0 +1,82 @@
+import re
+from aidente_voice.models import Chunk
+
+TAG_RE = re.compile(r'<(speed|pause|gacha|sfx)=([^>]+)>')
+SENTENCE_END_RE = re.compile(r'(?<=[。！？])\s*|\n+')
+
+
+class ParseError(ValueError):
+    pass
+
+
+def _parse_sfx_args(value: str) -> tuple[str, float]:
+    """Parse sfx tag value like 'laugh' or 'laugh,fade=0.1'."""
+    parts = value.split(",")
+    name = parts[0].strip()
+    fade = 0.05
+    for part in parts[1:]:
+        if part.strip().startswith("fade="):
+            fade = float(part.strip()[5:])
+    return name, fade
+
+
+def parse(text: str) -> list[Chunk]:
+    """Parse script text with control tags into a Chunk list."""
+    tokens = []
+    last = 0
+    for m in TAG_RE.finditer(text):
+        if m.start() > last:
+            tokens.append(("text", text[last:m.start()]))
+        tokens.append(("tag", m.group(1), m.group(2)))
+        last = m.end()
+    if last < len(text):
+        tokens.append(("text", text[last:]))
+
+    chunks: list[Chunk] = []
+    index = 0
+    gacha_pending: int | None = None
+    deferred_sfx: list[tuple[str, float]] = []
+
+    def add(chunk: Chunk) -> None:
+        nonlocal index
+        chunk.index = index
+        chunks.append(chunk)
+        index += 1
+
+    for token in tokens:
+        if token[0] == "text":
+            segments = [s.strip() for s in SENTENCE_END_RE.split(token[1])]
+            segments = [s for s in segments if s]
+            for seg in segments:
+                if gacha_pending is not None:
+                    add(Chunk(index=0, type="gacha", text=seg, gacha_n=gacha_pending))
+                    gacha_pending = None
+                    for sfx_name, sfx_fade in deferred_sfx:
+                        add(Chunk(index=0, type="sfx", sfx_name=sfx_name, sfx_fade=sfx_fade))
+                    deferred_sfx.clear()
+                else:
+                    add(Chunk(index=0, type="tts", text=seg))
+
+        elif token[0] == "tag":
+            _, name, value = token
+            if name == "speed":
+                if not chunks or chunks[-1].type not in ("tts", "gacha"):
+                    raise ParseError(
+                        f"<speed> tag has no preceding sentence to attach to."
+                    )
+                chunks[-1].speed = float(value)
+
+            elif name == "pause":
+                add(Chunk(index=0, type="pause", duration=float(value)))
+
+            elif name == "gacha":
+                gacha_pending = int(value)
+
+            elif name == "sfx":
+                sfx_name, sfx_fade = _parse_sfx_args(value)
+                if gacha_pending is not None:
+                    deferred_sfx.append((sfx_name, sfx_fade))
+                else:
+                    add(Chunk(index=0, type="sfx", sfx_name=sfx_name, sfx_fade=sfx_fade))
+
+    return chunks

--- a/aidente_voice/pipeline/assembler.py
+++ b/aidente_voice/pipeline/assembler.py
@@ -1,0 +1,70 @@
+import io
+import sys
+from pathlib import Path
+from pydub import AudioSegment
+from aidente_voice.models import Chunk
+
+SAMPLE_RATE = 24000
+CHANNELS = 1
+SAMPLE_WIDTH = 2  # 16-bit
+
+
+def _make_silence(duration_sec: float) -> AudioSegment:
+    return AudioSegment.silent(
+        duration=int(duration_sec * 1000),
+        frame_rate=SAMPLE_RATE,
+    ).set_channels(CHANNELS).set_sample_width(SAMPLE_WIDTH)
+
+
+def _load_sfx(path: Path, fade_sec: float) -> AudioSegment:
+    clip = AudioSegment.from_wav(str(path))
+    if clip.frame_rate != SAMPLE_RATE or clip.channels != CHANNELS:
+        print(
+            f"[WARN] {path.name} is {clip.frame_rate}Hz "
+            f"{'stereo' if clip.channels == 2 else str(clip.channels) + 'ch'}"
+            " — auto-converting to 24kHz mono.",
+            file=sys.stderr,
+        )
+        clip = clip.set_frame_rate(SAMPLE_RATE).set_channels(CHANNELS)
+    clip = clip.set_sample_width(SAMPLE_WIDTH)
+    if fade_sec > 0:
+        fade_ms = int(fade_sec * 1000)
+        clip = clip.fade_in(fade_ms).fade_out(fade_ms)
+    return clip
+
+
+def _bytes_to_segment(audio_bytes: bytes) -> AudioSegment:
+    return AudioSegment.from_wav(io.BytesIO(audio_bytes))
+
+
+def assemble(
+    chunks_with_audio: list[tuple[Chunk, bytes | None]],
+    sfx_dir: Path | None = None,
+    output_path: Path | None = None,
+) -> AudioSegment:
+    """Concatenate chunks into a final AudioSegment. Optionally export to file."""
+    if sfx_dir is None:
+        sfx_dir = Path.home() / ".aidente" / "sfx"
+
+    result = AudioSegment.empty()
+
+    for chunk, audio_bytes in chunks_with_audio:
+        if chunk.type in ("tts", "gacha"):
+            result += _bytes_to_segment(audio_bytes)  # type: ignore[arg-type]
+
+        elif chunk.type == "pause":
+            result += _make_silence(chunk.duration or 0.0)
+
+        elif chunk.type == "sfx":
+            sfx_path = sfx_dir / f"{chunk.sfx_name}.wav"
+            if not sfx_path.exists():
+                raise FileNotFoundError(
+                    f"SFX file not found: {sfx_path}. "
+                    f"Add the file or remove the <sfx> tag."
+                )
+            result += _load_sfx(sfx_path, fade_sec=chunk.sfx_fade)
+
+    if output_path:
+        result.export(str(output_path), format="wav")
+
+    return result

--- a/aidente_voice/pipeline/orchestrator.py
+++ b/aidente_voice/pipeline/orchestrator.py
@@ -1,0 +1,49 @@
+"""Sequential TTS pipeline orchestrator."""
+
+import tempfile
+from pathlib import Path
+
+from aidente_voice.gacha import GACHA_SEEDS, select_gacha
+from aidente_voice.models import Chunk
+from aidente_voice.pipeline.postprocess import apply_speed
+from aidente_voice.tts.client import TTSClient
+
+
+async def run_pipeline(
+    chunks: list[Chunk],
+    client: TTSClient,
+) -> list[tuple[Chunk, bytes | None]]:
+    """Run TTS pipeline sequentially, returning (chunk, audio_bytes) pairs."""
+    results = []
+    for chunk in chunks:
+        if chunk.type == "tts":
+            audio = await client.synthesize(chunk.text or "", seed=0)
+            if chunk.speed != 1.0:
+                audio = apply_speed(audio, chunk.speed)
+            results.append((chunk, audio))
+        elif chunk.type == "gacha":
+            audio = await _run_gacha(chunk, client)
+            results.append((chunk, audio))
+        else:
+            results.append((chunk, None))
+    return results
+
+
+async def _run_gacha(chunk: Chunk, client: TTSClient) -> bytes:
+    """Synthesize N gacha variants, let user pick one interactively."""
+    if chunk.gacha_n < 1:
+        raise ValueError(f"gacha_n must be >= 1, got {chunk.gacha_n}")
+    seeds = GACHA_SEEDS[:chunk.gacha_n]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        paths = []
+
+        for i, seed in enumerate(seeds):
+            audio_bytes = await client.synthesize(chunk.text or "", seed=seed)
+            path = tmp_path / f"gacha_{i}.wav"
+            path.write_bytes(audio_bytes)
+            paths.append(path)
+
+        selected_idx = select_gacha(paths, chunk.text or "", chunk.index)
+        return paths[selected_idx].read_bytes()

--- a/aidente_voice/pipeline/postprocess.py
+++ b/aidente_voice/pipeline/postprocess.py
@@ -1,0 +1,46 @@
+import tempfile
+import os
+import ffmpeg
+
+AUDIO_SAMPLE_RATE = 24000
+
+
+def build_atempo_chain(speed: float) -> list[float]:
+    """Factorize speed into atempo filter values, each in [0.5, 2.0]."""
+    if speed == 1.0:
+        return [1.0]
+    factors: list[float] = []
+    remaining = speed
+    while remaining < 0.5:
+        factors.append(0.5)
+        remaining /= 0.5
+    while remaining > 2.0:
+        factors.append(2.0)
+        remaining /= 2.0
+    factors.append(remaining)
+    return factors
+
+
+def apply_speed(audio_bytes: bytes, speed: float) -> bytes:
+    """Apply time-stretch to audio bytes using ffmpeg atempo. Returns WAV bytes."""
+    if speed == 1.0:
+        return audio_bytes
+
+    factors = build_atempo_chain(speed)
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as in_f:
+        in_f.write(audio_bytes)
+        in_path = in_f.name
+
+    out_path = in_path.replace(".wav", "_out.wav")
+    try:
+        stream = ffmpeg.input(in_path).audio
+        for factor in factors:
+            stream = ffmpeg.filter(stream, "atempo", factor)
+        ffmpeg.output(stream, out_path).run(quiet=True, overwrite_output=True)
+        with open(out_path, "rb") as f:
+            return f.read()
+    finally:
+        os.unlink(in_path)
+        if os.path.exists(out_path):
+            os.unlink(out_path)

--- a/aidente_voice/tts/client.py
+++ b/aidente_voice/tts/client.py
@@ -1,0 +1,5 @@
+from typing import Protocol
+
+
+class TTSClient(Protocol):
+    async def synthesize(self, text: str, seed: int = 0) -> bytes: ...

--- a/tests/test_integration_phase2.py
+++ b/tests/test_integration_phase2.py
@@ -1,6 +1,7 @@
 """Phase 2 integration tests: gacha workflow."""
 
 import io
+import math
 import struct
 import wave
 from pathlib import Path
@@ -26,7 +27,6 @@ def _make_wav_bytes(seed: int = 0, duration_ms: int = 100) -> bytes:
         wf.setframerate(sample_rate)
         # Use seed to vary the frequency slightly
         freq = 440 + seed * 10
-        import math
         frames = struct.pack(f'<{n_samples}h', *[
             int(32767 * math.sin(2 * math.pi * freq * i / sample_rate))
             for i in range(n_samples)
@@ -42,7 +42,7 @@ class FakeTTSClient:
 
 
 @pytest.mark.asyncio
-async def test_gacha_selects_correct_variant(tmp_path):
+async def test_gacha_selects_correct_variant():
     """Pipeline returns audio for the seed at the selected gacha index."""
     from aidente_voice.gacha import GACHA_SEEDS
 
@@ -62,7 +62,7 @@ async def test_gacha_selects_correct_variant(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_gacha_mixed_with_tts(tmp_path):
+async def test_gacha_mixed_with_tts():
     """Pipeline handles a mix of tts and gacha chunks correctly."""
     from aidente_voice.gacha import GACHA_SEEDS
 

--- a/tests/test_integration_phase2.py
+++ b/tests/test_integration_phase2.py
@@ -1,0 +1,91 @@
+"""Phase 2 integration tests: gacha workflow."""
+
+import io
+import struct
+import wave
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from aidente_voice.models import Chunk
+from aidente_voice.pipeline.assembler import assemble
+from aidente_voice.pipeline.orchestrator import run_pipeline
+
+
+def _make_wav_bytes(seed: int = 0, duration_ms: int = 100) -> bytes:
+    """Generate a minimal valid WAV at 24kHz mono 16-bit.
+    Uses seed to produce distinct audio for each variant.
+    """
+    sample_rate = 24000
+    n_samples = int(sample_rate * duration_ms / 1000)
+    buf = io.BytesIO()
+    with wave.open(buf, 'wb') as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        # Use seed to vary the frequency slightly
+        freq = 440 + seed * 10
+        import math
+        frames = struct.pack(f'<{n_samples}h', *[
+            int(32767 * math.sin(2 * math.pi * freq * i / sample_rate))
+            for i in range(n_samples)
+        ])
+        wf.writeframes(frames)
+    return buf.getvalue()
+
+
+class FakeTTSClient:
+    """Returns distinct audio bytes per seed for deterministic testing."""
+    async def synthesize(self, text: str, seed: int = 0) -> bytes:
+        return _make_wav_bytes(seed=seed)
+
+
+@pytest.mark.asyncio
+async def test_gacha_selects_correct_variant(tmp_path):
+    """Pipeline returns audio for the seed at the selected gacha index."""
+    from aidente_voice.gacha import GACHA_SEEDS
+
+    chunks = [
+        Chunk(index=0, type="gacha", text="テスト", gacha_n=3),
+    ]
+    client = FakeTTSClient()
+
+    # User selects variant 2 (index 2, which uses GACHA_SEEDS[2])
+    with patch("aidente_voice.pipeline.orchestrator.select_gacha", return_value=2):
+        results = await run_pipeline(chunks, client)
+
+    assert len(results) == 1
+    chunk, audio_bytes = results[0]
+    expected = _make_wav_bytes(seed=GACHA_SEEDS[2])
+    assert audio_bytes == expected
+
+
+@pytest.mark.asyncio
+async def test_gacha_mixed_with_tts(tmp_path):
+    """Pipeline handles a mix of tts and gacha chunks correctly."""
+    from aidente_voice.gacha import GACHA_SEEDS
+
+    chunks = [
+        Chunk(index=0, type="tts", text="こんにちは"),
+        Chunk(index=1, type="gacha", text="笑い", gacha_n=2),
+        Chunk(index=2, type="pause", duration=0.5),
+    ]
+    client = FakeTTSClient()
+
+    with patch("aidente_voice.pipeline.orchestrator.select_gacha", return_value=1):
+        results = await run_pipeline(chunks, client)
+
+    assert len(results) == 3
+
+    # TTS chunk: uses seed=0
+    _, tts_audio = results[0]
+    assert tts_audio == _make_wav_bytes(seed=0)
+
+    # Gacha chunk: user selected index 1, so uses GACHA_SEEDS[1]
+    _, gacha_audio = results[1]
+    assert gacha_audio == _make_wav_bytes(seed=GACHA_SEEDS[1])
+
+    # Pause chunk: no audio
+    _, pause_audio = results[2]
+    assert pause_audio is None


### PR DESCRIPTION
Integration tests covering gacha variant selection with mocked select_gacha and real WAV audio bytes.

## What's included

- `FakeTTSClient` that returns deterministic 100ms sine-wave WAV bytes keyed by seed
- `test_gacha_selects_correct_variant`: verifies the pipeline returns audio for the user-selected gacha index
- `test_gacha_mixed_with_tts`: verifies correct audio for a mixed chunk list (tts + gacha + pause)
- Sources all needed production files from `task/10-integration-phase1` and `task/12-gacha-orchestrator`

Closes #14