### PR TITLE
feat: per-chunk acoustic control via <style=...> tag

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1,0 +1,359 @@
+# aidente-voice 使用手冊
+
+aidente-voice 是一個 TTS 製作工具，讓你在腳本裡用標籤精確控制語速、停頓、說話風格、音效，以及互動式音色抽選（Gacha），最終輸出混音完成的音訊檔案。
+
+---
+
+## 目錄
+
+1. [安裝](#安裝)
+2. [設定 API](#設定-api)
+3. [撰寫腳本](#撰寫腳本)
+4. [標籤參考](#標籤參考)
+5. [CLI 指令](#cli-指令)
+6. [聲學屬性控制](#聲學屬性控制)
+7. [音效（SFX）](#音效sfx)
+8. [Gacha 互動選音](#gacha-互動選音)
+9. [常見用法範例](#常見用法範例)
+10. [錯誤排除](#錯誤排除)
+
+---
+
+## 安裝
+
+需求：Python 3.11+、[uv](https://docs.astral.sh/uv/)、ffmpeg
+
+```bash
+brew install ffmpeg   # macOS
+uv sync
+```
+
+---
+
+## 設定 API
+
+### 端點說明
+
+| 端點 | 說明 |
+|------|------|
+| `/custom-voice` | 使用預設音色（**推薦**） |
+| `/voice-design` | 用自然語言描述音色特質 |
+
+```bash
+export MODAL_TTS_URL="https://waiting-hchs--qwen3-tts-qwen3tts-api.modal.run/custom-voice"
+
+# 永久生效
+echo 'export MODAL_TTS_URL="https://..."' >> ~/.zshrc && source ~/.zshrc
+```
+
+---
+
+## 撰寫腳本
+
+腳本是純文字檔（`.txt`）。日文 `。！？` 或換行自動切分成語音片段，標籤放在句子**後面**控制該句屬性。
+
+```
+こんにちは。
+少しゆっくり話します。<speed=0.8>
+<pause=1.5>
+怒りながら叫ぶ！<style=very angry, shouting>
+そっと囁く。<style=whisper, intimate>
+```
+
+---
+
+## 標籤參考
+
+### `<pause=秒數>`
+
+插入靜音。
+
+```
+準備はよろしいですか。<pause=2>では、始めましょう。
+```
+
+---
+
+### `<speed=倍率>`
+
+調整**前一句**語速。
+
+```
+ゆっくり話す。<speed=0.7>
+早口で話す。<speed=1.5>
+```
+
+| 值 | 效果 |
+|----|------|
+| `0.5` | 極慢（半速） |
+| `0.8` | 稍慢 |
+| `1.0` | 正常 |
+| `1.3` | 稍快 |
+| `2.0` | 極快（倍速） |
+
+> 支援範圍 `0.1` ～ `5.0`。不能獨立存在，必須接在句子後面。
+
+---
+
+### `<style=描述>`
+
+控制**前一句**的說話風格、情緒、語調。透過 Qwen3-TTS 的 `instruct` 欄位實現。
+
+```
+普通に話す。
+怒りながら叫ぶ！<style=very angry, shouting>
+そっと囁く。<style=whisper, slow, intimate>
+笑いながら話す。<style=laughing, joyful>
+震える声で。<style=voice trembling with fear, barely audible>
+```
+
+**Qwen3-TTS 支援的聲學屬性：**
+
+| 屬性類型 | 範例描述 |
+|----------|---------|
+| 情緒 | `happy`、`sad`、`angry`、`excited`、`nervous`、`disappointed` |
+| 說話方式 | `whisper`、`shouting`、`laughing`、`crying`、`sighing` |
+| 語速 | `very slow`、`fast`、`rushed`、`dragging each word` |
+| 音調 | `high pitch`、`low and deep`、`monotone`、`rising intonation` |
+| 角色風格 | `like a news anchor`、`like a child`、`like a villain` |
+| 複合描述 | `speak slowly with trembling voice, as if about to cry` |
+
+> **優先級：** `<style=...>` 逐句標籤 > `--instruct` 全域設定。
+> 每句可獨立設定，不設定的句子沿用全域 `--instruct`（若有）。
+
+---
+
+### `<sfx=音效名[,fade=秒數]>`
+
+插入音效。
+
+```
+<sfx=laugh>
+<sfx=applause,fade=0.3>
+```
+
+---
+
+### `<gacha=N>`
+
+對**前一句**合成 N 個音色變體，讓你互動選擇。
+
+```
+この台詞は何度も録り直したい。<gacha=4>
+```
+
+可搭配 `<style=...>` 使用：
+
+```
+怒りながら笑う複雑な表情。<gacha=3><style=angry yet laughing, conflicted>
+```
+
+---
+
+## CLI 指令
+
+### `aidente-voice generate`
+
+```bash
+uv run aidente-voice generate -i <腳本路徑> [選項]
+```
+
+#### 基本選項
+
+| 選項 | 預設 | 說明 |
+|------|------|------|
+| `-i / --input` | **必填** | 輸入腳本路徑 |
+| `-o / --output` | `output.wav` | 輸出路徑 |
+| `--dry-run` | `false` | 只顯示解析結果，不呼叫 API |
+| `--keep-chunks` | `false` | 保留個別片段到 `./chunks/` |
+| `--max-concurrent` | `10` | 最大同時合成請求數 |
+| `--sfx-dir` | `~/.aidente/sfx` | 音效目錄 |
+
+#### 音色選項
+
+| 選項 | 預設 | 說明 |
+|------|------|------|
+| `--speaker` | `Ryan` | 預設音色 |
+| `--language` | `Auto` | 語言提示 |
+| `--instruct` | 無 | 全域說話風格（可被 `<style=...>` 逐句覆蓋） |
+| `--voice-design` | 無 | 改用 `/voice-design` 端點，值為音色描述 |
+
+**可選音色（`--speaker`）：**
+
+| 音色 | 特性 |
+|------|------|
+| `Ryan`（預設） | 成熟男聲 |
+| `Aiden` | 年輕男聲 |
+| `Dylan` | 低沉男聲 |
+| `Eric` | 中性男聲 |
+| `Ono_anna` | 日系女聲 |
+| `Serena` | 成熟女聲 |
+| `Vivian` | 活潑女聲 |
+| `Sohee` | 韓系女聲 |
+| `Uncle_fu` | 老者男聲 |
+
+**可選語言（`--language`）：**
+`Auto`、`Chinese`、`English`、`Japanese`、`Korean`、`French`、`German`、`Spanish`、`Portuguese`、`Russian`
+
+---
+
+## 聲學屬性控制
+
+Qwen3-TTS 的 `instruct` 欄位支援自然語言描述，本工具提供兩個層級：
+
+### 層級 1：全域風格（`--instruct`）
+
+整份腳本的預設風格：
+
+```bash
+uv run aidente-voice generate -i script.txt \
+  --speaker Serena \
+  --instruct "Speak slowly and warmly, like a caring teacher"
+```
+
+### 層級 2：逐句風格（`<style=...>`）
+
+覆蓋特定句子的風格：
+
+```
+# script.txt
+普通に話す。
+怒りながら叫ぶ！<style=very angry, shouting>
+冷静に戻る。
+```
+
+### 組合使用
+
+```bash
+# 全域：溫柔說話
+# 但腳本中指定的句子會有自己的風格
+uv run aidente-voice generate -i script.txt \
+  --speaker Ono_anna \
+  --language Japanese \
+  --instruct "warm and gentle"
+```
+
+```
+# script.txt
+いつもありがとう。              ← 溫柔（全域）
+なんでそんなこと言うの！<style=hurt and tearful>  ← 覆蓋
+また明日ね。                    ← 溫柔（全域）
+```
+
+### 用描述設計全新音色（`--voice-design`）
+
+不使用預設音色，直接描述你想要的聲音：
+
+```bash
+uv run aidente-voice generate -i script.txt \
+  --voice-design "A young enthusiastic male developer, slightly sarcastic but friendly, mid-range voice"
+```
+
+---
+
+## 音效（SFX）
+
+`.wav` 格式，放在 `~/.aidente/sfx/`（或 `--sfx-dir` 指定目錄）。工具自動重新取樣為 24kHz 單聲道。
+
+```bash
+mkdir -p ~/.aidente/sfx
+cp laugh.wav ~/.aidente/sfx/
+```
+
+---
+
+## Gacha 互動選音
+
+腳本有 `<gacha=N>` 時，工具先合成所有普通語音，再逐一進入選音介面。
+
+```
+[Gacha] Chunk 2: '怒りながら笑う複雑な表情。'
+  Variants: 3 | Keys: 1-3 to play, Enter to confirm, q to quit
+```
+
+| 按鍵 | 動作 |
+|------|------|
+| `1` ～ `N` | 試聽對應變體 |
+| `Enter` | 確認（若未試聽，自動播第一個） |
+| `q` | 使用第一個變體 |
+
+---
+
+## 常見用法範例
+
+### Dry run（確認解析結果）
+
+```bash
+uv run aidente-voice generate -i script.txt --dry-run
+# 輸出：
+# [DRY RUN] Parsed 4 chunks:
+#   [0] tts    "普通に話す。"
+#   [1] tts    "怒りながら叫ぶ！" style='very angry, shouting'
+#   [2] pause  1.5s
+#   [3] tts    "そっと囁く。" style='whisper, intimate'
+```
+
+### 基本合成
+
+```bash
+uv run aidente-voice generate -i script.txt -o output.wav
+```
+
+### 逐句情緒控制
+
+```bash
+# script.txt:
+# 今日はいい天気ですね。
+# なんで遅刻したの！<style=angry, sharp tone>
+# ...ごめんなさい。<style=apologetic, quiet>
+
+uv run aidente-voice generate -i script.txt --speaker Serena --language Japanese
+```
+
+### 全域 + 逐句組合
+
+```bash
+uv run aidente-voice generate -i script.txt \
+  --speaker Ono_anna \
+  --instruct "calm and professional" \
+  --language Japanese
+# 個別 <style=...> 標籤會覆蓋 "calm and professional"
+```
+
+### 音色設計模式
+
+```bash
+uv run aidente-voice generate -i script.txt \
+  --voice-design "A slightly husky narrator, mid-40s male, speaking with gravitas and warmth"
+```
+
+---
+
+## 錯誤排除
+
+### `MODAL_TTS_URL environment variable not set`
+```bash
+export MODAL_TTS_URL="https://waiting-hchs--qwen3-tts-qwen3tts-api.modal.run/custom-voice"
+```
+
+### `ParseError: <style> tag has no preceding sentence`
+`<style>` 必須接在句子後面，不能獨立存在：
+```
+# ❌
+<style=angry> 叫ぶ！
+
+# ✅
+叫ぶ！<style=angry, shouting>
+```
+
+### `ParseError: <speed> tag has no preceding sentence`
+同上，`<speed>` 也必須接在句子後面。
+
+### API 422 錯誤
+確認 `--speaker` 值在允許清單內：
+`Aiden, Dylan, Eric, Ono_anna, Ryan, Serena, Sohee, Uncle_fu, Vivian`
+
+### 音效找不到
+```bash
+ls ~/.aidente/sfx/   # 確認檔案存在且名稱吻合
+```

--- a/aidente_voice/cli.py
+++ b/aidente_voice/cli.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import sys
 from pathlib import Path
 
 import typer
@@ -8,7 +7,7 @@ from rich.console import Console
 
 from aidente_voice.models import Chunk
 from aidente_voice.parser import parse, ParseError
-from aidente_voice.tts.modal_client import ModalTTSClient
+from aidente_voice.tts.modal_client import ModalTTSClient, CustomVoiceConfig, VoiceDesignConfig
 from aidente_voice.pipeline.orchestrator import run_pipeline
 from aidente_voice.pipeline.assembler import assemble
 
@@ -26,11 +25,13 @@ def _dry_run_report(chunks: list[Chunk]) -> None:
     for c in chunks:
         if c.type == "tts":
             speed_str = f" speed={c.speed}" if c.speed != 1.0 else ""
-            console.print(f"  [{c.index}] tts    \"{c.text}\"{speed_str}")
+            style_str = f" style={c.instruct!r}" if c.instruct else ""
+            console.print(f"  [{c.index}] tts    \"{c.text}\"{speed_str}{style_str}")
         elif c.type == "pause":
             console.print(f"  [{c.index}] pause  {c.duration}s")
         elif c.type == "gacha":
-            console.print(f"  [{c.index}] gacha  \"{c.text}\" n={c.gacha_n}")
+            style_str = f" style={c.instruct!r}" if c.instruct else ""
+            console.print(f"  [{c.index}] gacha  \"{c.text}\" n={c.gacha_n}{style_str}")
         elif c.type == "sfx":
             console.print(f"  [{c.index}] sfx    {c.sfx_name} fade={c.sfx_fade}")
     console.print("No API calls made.")
@@ -44,8 +45,43 @@ def generate(
     max_concurrent: int = typer.Option(10, "--max-concurrent"),
     keep_chunks: bool = typer.Option(False, "--keep-chunks"),
     dry_run: bool = typer.Option(False, "--dry-run"),
+    # Voice options
+    speaker: str = typer.Option(
+        "Ryan",
+        "--speaker",
+        help="Speaker: Aiden, Dylan, Eric, Ono_anna, Ryan, Serena, Sohee, Uncle_fu, Vivian",
+    ),
+    language: str = typer.Option(
+        "Auto",
+        "--language",
+        help="Language: Auto, Chinese, English, Japanese, Korean, French, German, Spanish, Portuguese, Russian",
+    ),
+    instruct: str | None = typer.Option(
+        None,
+        "--instruct",
+        help='Global speaking style, e.g. "Speak slowly with a warm tone". Overridden per-sentence by <style=...> tags.',
+    ),
+    voice_design: str | None = typer.Option(
+        None,
+        "--voice-design",
+        help='Use /voice-design endpoint. Describe the voice: "A warm husky male narrator"',
+    ),
 ) -> None:
-    """Generate TTS audio from a script with control tags."""
+    """Generate TTS audio from a script with control tags.
+
+    Acoustic attributes can be controlled globally via --instruct,
+    or per-sentence in the script using <style=...> tags.
+
+    Examples:
+        --instruct "Speak slowly and warmly"
+        --speaker Ono_anna --language Japanese
+        --voice-design "A young enthusiastic male, slightly sarcastic but friendly"
+
+    In-script style tag:
+        普通に話す。
+        怒りながら叫ぶ。<style=very angry, shouting>
+        そっと囁く。<style=whisper, intimate>
+    """
     if not input.exists():
         console.print(f"[red][ERROR][/] Input file not found: {input}")
         raise typer.Exit(code=1)
@@ -67,7 +103,22 @@ def generate(
         console.print("[red][ERROR][/] MODAL_TTS_URL environment variable not set.")
         raise typer.Exit(code=1)
 
-    client = ModalTTSClient(endpoint_url=modal_url)
+    if voice_design is not None:
+        # Strip endpoint suffix if user set URL to /custom-voice, swap to /voice-design
+        base = modal_url.rstrip("/")
+        for suffix in ("/custom-voice", "/voice-design", "/voice-clone"):
+            if base.endswith(suffix):
+                base = base[: -len(suffix)]
+                break
+        tts_url = f"{base}/voice-design"
+        config: CustomVoiceConfig | VoiceDesignConfig = VoiceDesignConfig(
+            instruct=voice_design, language=language
+        )
+    else:
+        tts_url = modal_url
+        config = CustomVoiceConfig(speaker=speaker, language=language, instruct=instruct)
+
+    client = ModalTTSClient(endpoint_url=tts_url, config=config)
 
     try:
         results = asyncio.run(run_pipeline(chunks, client=client))

--- a/aidente_voice/models.py
+++ b/aidente_voice/models.py
@@ -12,3 +12,4 @@ class Chunk:
     gacha_n: int = 1
     sfx_name: str | None = None
     sfx_fade: float = 0.05
+    instruct: str | None = None

--- a/aidente_voice/parser.py
+++ b/aidente_voice/parser.py
@@ -1,7 +1,7 @@
 import re
 from aidente_voice.models import Chunk
 
-TAG_RE = re.compile(r'<(speed|pause|gacha|sfx)=([^>]+)>')
+TAG_RE = re.compile(r'<(speed|pause|gacha|sfx|style)=([^>]+)>')
 SENTENCE_END_RE = re.compile(r'(?<=[。！？])\s*|\n+')
 
 
@@ -78,5 +78,12 @@ def parse(text: str) -> list[Chunk]:
                     deferred_sfx.append((sfx_name, sfx_fade))
                 else:
                     add(Chunk(index=0, type="sfx", sfx_name=sfx_name, sfx_fade=sfx_fade))
+
+            elif name == "style":
+                if not chunks or chunks[-1].type not in ("tts", "gacha"):
+                    raise ParseError(
+                        f"<style> tag has no preceding sentence to attach to."
+                    )
+                chunks[-1].instruct = value.strip()
 
     return chunks

--- a/aidente_voice/pipeline/orchestrator.py
+++ b/aidente_voice/pipeline/orchestrator.py
@@ -16,7 +16,7 @@ async def run_pipeline(
 
     for chunk in chunks:
         if chunk.type in ("tts", "gacha"):
-            audio = await client.synthesize(chunk.text or "", seed=0)
+            audio = await client.synthesize(chunk.text or "", seed=0, instruct=chunk.instruct)
             if chunk.speed != 1.0:
                 audio = apply_speed(audio, chunk.speed)
             results.append((chunk, audio))

--- a/aidente_voice/tts/modal_client.py
+++ b/aidente_voice/tts/modal_client.py
@@ -50,10 +50,14 @@ class ModalTTSClient:
         self._config = config or CustomVoiceConfig()
 
     def _build_payload(self, text: str, instruct: str | None = None) -> dict:
-        # Per-call instruct overrides config-level instruct
-        effective_instruct = instruct if instruct is not None else (
-            self._config.instruct if isinstance(self._config, CustomVoiceConfig) else None
-        )
+        # Merge global config instruct with per-call instruct (from <style=...> tag).
+        # Both present: "global; per-sentence" so the model sees full context.
+        # Only one present: use whichever exists.
+        config_instruct = self._config.instruct if isinstance(self._config, CustomVoiceConfig) else None
+        if config_instruct and instruct:
+            effective_instruct = f"{config_instruct}; {instruct}"
+        else:
+            effective_instruct = instruct or config_instruct
 
         if isinstance(self._config, VoiceDesignConfig):
             return {

--- a/aidente_voice/tts/modal_client.py
+++ b/aidente_voice/tts/modal_client.py
@@ -1,19 +1,90 @@
+"""Modal TTS API client supporting custom-voice and voice-design endpoints."""
+
 import asyncio
+from dataclasses import dataclass
+
 import requests
-from aidente_voice.tts.client import TTSClient  # noqa: F401 (for type checking)
 
 _RETRY_DELAYS = [1.0, 2.0, 4.0]
 
 
-class ModalTTSClient:
-    def __init__(self, endpoint_url: str) -> None:
-        self._url = endpoint_url
+@dataclass
+class CustomVoiceConfig:
+    """Configuration for the /custom-voice endpoint.
 
-    async def synthesize(self, text: str, seed: int = 0) -> bytes:
-        payload = {"text": text, "seed": seed}
+    Speakers: Aiden, Dylan, Eric, Ono_anna, Ryan, Serena, Sohee, Uncle_fu, Vivian
+    Languages: Auto, Chinese, English, Japanese, Korean, French, German,
+               Spanish, Portuguese, Russian
+    """
+
+    speaker: str = "Ryan"
+    language: str = "Auto"
+    instruct: str | None = None
+
+
+@dataclass
+class VoiceDesignConfig:
+    """Configuration for the /voice-design endpoint.
+
+    instruct: natural language description of the desired voice.
+    Example: "A warm, slightly raspy female voice speaking slowly"
+    """
+
+    instruct: str
+    language: str = "Auto"
+
+
+class ModalTTSClient:
+    """TTS client for the Modal-hosted Qwen3-TTS API.
+
+    Supports /custom-voice and /voice-design endpoints.
+    Per-call instruct (from <style=...> tags) overrides the config-level instruct.
+    """
+
+    def __init__(
+        self,
+        endpoint_url: str,
+        config: CustomVoiceConfig | VoiceDesignConfig | None = None,
+    ) -> None:
+        self._url = endpoint_url
+        self._config = config or CustomVoiceConfig()
+
+    def _build_payload(self, text: str, instruct: str | None = None) -> dict:
+        # Per-call instruct overrides config-level instruct
+        effective_instruct = instruct if instruct is not None else (
+            self._config.instruct if isinstance(self._config, CustomVoiceConfig) else None
+        )
+
+        if isinstance(self._config, VoiceDesignConfig):
+            return {
+                "text": text,
+                "language": self._config.language,
+                "instruct": effective_instruct or self._config.instruct,
+            }
+
+        # CustomVoiceConfig
+        payload: dict = {
+            "text": text,
+            "language": self._config.language,
+            "speaker": self._config.speaker,
+        }
+        if effective_instruct:
+            payload["instruct"] = effective_instruct
+        return payload
+
+    async def synthesize(self, text: str, seed: int = 0, instruct: str | None = None) -> bytes:
+        """Synthesize text to audio bytes.
+
+        Args:
+            text: Text to synthesize.
+            seed: Ignored (API uses LLM sampling for variation; kept for interface compat).
+            instruct: Per-call style override, e.g. from <style=...> tag.
+                      Overrides config-level instruct for this call only.
+        """
+        payload = self._build_payload(text, instruct=instruct)
         last_exc: Exception | None = None
 
-        for attempt, delay in enumerate([0.0] + _RETRY_DELAYS):
+        for delay in [0.0] + _RETRY_DELAYS:
             if delay:
                 await asyncio.sleep(delay)
             try:
@@ -21,7 +92,7 @@ class ModalTTSClient:
                 if response.status_code == 200:
                     return response.content
                 last_exc = RuntimeError(
-                    f"TTS API failed: status {response.status_code}"
+                    f"TTS API failed: status {response.status_code}: {response.text[:200]}"
                 )
             except requests.RequestException as e:
                 last_exc = e

--- a/tests/pipeline/test_orchestrator.py
+++ b/tests/pipeline/test_orchestrator.py
@@ -18,7 +18,7 @@ async def test_tts_chunks_are_synthesized(mock_client):
         Chunk(index=0, type="tts", text="Hello world。"),
     ]
     result = await run_pipeline(chunks, client=mock_client)
-    mock_client.synthesize.assert_called_once_with("Hello world。", seed=0)
+    mock_client.synthesize.assert_called_once_with("Hello world。", seed=0, instruct=None)
     assert len(result) == 1
     assert result[0][0] == chunks[0]
 

--- a/tests/test_integration_phase1.py
+++ b/tests/test_integration_phase1.py
@@ -22,7 +22,7 @@ def _make_wav_bytes(duration_ms: int = 300) -> bytes:
 
 
 class FakeTTSClient:
-    async def synthesize(self, text: str, seed: int = 0) -> bytes:
+    async def synthesize(self, text: str, seed: int = 0, instruct: str | None = None) -> bytes:
         return _make_wav_bytes(300)
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -70,3 +70,21 @@ def test_full_example():
 def test_empty_text_segments_ignored():
     chunks = parse("Hello。\n\nWorld。")
     assert len(chunks) == 2
+
+def test_style_tag_attaches_to_preceding():
+    chunks = parse("怒りながら叫ぶ。<style=very angry, shouting>")
+    assert chunks[0].instruct == "very angry, shouting"
+
+def test_style_tag_at_start_raises():
+    with pytest.raises(ParseError, match="no preceding sentence"):
+        parse("<style=angry> Some sentence。")
+
+def test_style_tag_does_not_affect_speed():
+    chunks = parse("怒りながらゆっくり。<speed=0.7><style=angry but slow>")
+    assert chunks[0].speed == 0.7
+    assert chunks[0].instruct == "angry but slow"
+
+def test_style_tag_independent_per_chunk():
+    chunks = parse("普通に話す。\n怒りながら。<style=very angry>")
+    assert chunks[0].instruct is None
+    assert chunks[1].instruct == "very angry"

--- a/tests/tts/test_modal_client.py
+++ b/tests/tts/test_modal_client.py
@@ -41,11 +41,11 @@ async def test_custom_voice_payload(client):
 
 
 @pytest.mark.asyncio
-async def test_per_call_instruct_overrides_config():
-    """<style=...> tag instruct overrides config-level instruct."""
+async def test_per_call_instruct_merges_with_config():
+    """<style=...> tag instruct is merged with config-level instruct."""
     client = ModalTTSClient(
         endpoint_url="https://fake.modal.run/custom-voice",
-        config=CustomVoiceConfig(speaker="Serena", language="Japanese", instruct="global style"),
+        config=CustomVoiceConfig(speaker="Serena", language="Japanese", instruct="calm and professional"),
     )
     mock_response = MagicMock()
     mock_response.status_code = 200
@@ -55,7 +55,7 @@ async def test_per_call_instruct_overrides_config():
         await client.synthesize("テスト", instruct="very angry, shouting")
 
     payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args.args[1]
-    assert payload["instruct"] == "very angry, shouting"
+    assert payload["instruct"] == "calm and professional; very angry, shouting"
 
 
 @pytest.mark.asyncio

--- a/tests/tts/test_modal_client.py
+++ b/tests/tts/test_modal_client.py
@@ -1,11 +1,14 @@
 import pytest
 from unittest.mock import patch, MagicMock
-from aidente_voice.tts.modal_client import ModalTTSClient
+from aidente_voice.tts.modal_client import ModalTTSClient, CustomVoiceConfig, VoiceDesignConfig
 
 
 @pytest.fixture
 def client():
-    return ModalTTSClient(endpoint_url="https://fake.modal.run/tts")
+    return ModalTTSClient(
+        endpoint_url="https://fake.modal.run/custom-voice",
+        config=CustomVoiceConfig(speaker="Ryan", language="Auto"),
+    )
 
 
 @pytest.mark.asyncio
@@ -15,25 +18,82 @@ async def test_synthesize_returns_bytes(client):
     mock_response.content = b"RIFF....fake_wav_bytes"
 
     with patch("requests.post", return_value=mock_response):
-        result = await client.synthesize("Hello world", seed=42)
+        result = await client.synthesize("Hello world")
 
     assert isinstance(result, bytes)
     assert result == b"RIFF....fake_wav_bytes"
 
 
 @pytest.mark.asyncio
-async def test_synthesize_sends_correct_payload(client):
+async def test_custom_voice_payload(client):
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.content = b"audio"
 
     with patch("requests.post", return_value=mock_response) as mock_post:
-        await client.synthesize("Test sentence", seed=1337)
+        await client.synthesize("Test sentence")
 
-    call_kwargs = mock_post.call_args
-    payload = call_kwargs.kwargs.get("json") or call_kwargs.args[1]
+    payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args.args[1]
     assert payload["text"] == "Test sentence"
-    assert payload["seed"] == 1337
+    assert payload["speaker"] == "Ryan"
+    assert payload["language"] == "Auto"
+    assert "seed" not in payload
+
+
+@pytest.mark.asyncio
+async def test_per_call_instruct_overrides_config():
+    """<style=...> tag instruct overrides config-level instruct."""
+    client = ModalTTSClient(
+        endpoint_url="https://fake.modal.run/custom-voice",
+        config=CustomVoiceConfig(speaker="Serena", language="Japanese", instruct="global style"),
+    )
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b"audio"
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        await client.synthesize("テスト", instruct="very angry, shouting")
+
+    payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args.args[1]
+    assert payload["instruct"] == "very angry, shouting"
+
+
+@pytest.mark.asyncio
+async def test_per_call_instruct_none_falls_back_to_config():
+    """When no per-call instruct, config-level instruct is used."""
+    client = ModalTTSClient(
+        endpoint_url="https://fake.modal.run/custom-voice",
+        config=CustomVoiceConfig(speaker="Ryan", language="Auto", instruct="slow and warm"),
+    )
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b"audio"
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        await client.synthesize("Hello")
+
+    payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args.args[1]
+    assert payload["instruct"] == "slow and warm"
+
+
+@pytest.mark.asyncio
+async def test_voice_design_payload():
+    """VoiceDesignConfig sends instruct instead of speaker."""
+    client = ModalTTSClient(
+        endpoint_url="https://fake.modal.run/voice-design",
+        config=VoiceDesignConfig(instruct="A warm female voice", language="Auto"),
+    )
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b"audio"
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        await client.synthesize("Hello")
+
+    payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args.args[1]
+    assert payload["instruct"] == "A warm female voice"
+    assert payload["language"] == "Auto"
+    assert "speaker" not in payload
 
 
 @pytest.mark.asyncio
@@ -41,14 +101,15 @@ async def test_synthesize_retries_on_failure(client):
     fail_response = MagicMock()
     fail_response.status_code = 500
     fail_response.content = b""
+    fail_response.text = "Internal Server Error"
 
     ok_response = MagicMock()
     ok_response.status_code = 200
     ok_response.content = b"audio"
 
     with patch("requests.post", side_effect=[fail_response, fail_response, ok_response]):
-        with patch("asyncio.sleep"):  # skip actual delays
-            result = await client.synthesize("Test", seed=0)
+        with patch("asyncio.sleep"):
+            result = await client.synthesize("Test")
 
     assert result == b"audio"
 
@@ -58,8 +119,9 @@ async def test_synthesize_raises_after_max_retries(client):
     fail_response = MagicMock()
     fail_response.status_code = 500
     fail_response.content = b""
+    fail_response.text = "error"
 
     with patch("requests.post", return_value=fail_response):
         with patch("asyncio.sleep"):
             with pytest.raises(RuntimeError, match="TTS API failed"):
-                await client.synthesize("Test", seed=0)
+                await client.synthesize("Test")


### PR DESCRIPTION
## Summary

Adds Qwen3-TTS acoustic attribute control at both global and per-sentence level.

## Changes

- **`Chunk`**: new `instruct: str | None` field
- **Parser**: `<style=描述>` tag attaches to preceding sentence, sets `chunk.instruct`
- **`ModalTTSClient`**: `CustomVoiceConfig` / `VoiceDesignConfig` dataclasses; per-call `instruct` param overrides config-level instruct
- **Orchestrator**: passes `chunk.instruct` to `synthesize()`
- **CLI**: `--speaker`, `--language` (default `Auto`), `--instruct`, `--voice-design` options
- **`USER_MANUAL.md`**: full Traditional Chinese manual

## Usage

```
# Global style
uv run aidente-voice generate -i script.txt --instruct "calm and warm" --speaker Serena

# Per-sentence style tags override global
普通に話す。
怒りながら叫ぶ！<style=very angry, shouting>
そっと囁く。<style=whisper, intimate>
```

Closes #32